### PR TITLE
add missing lifen-fhir dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "lifen-fhir.js": "^1.6.3"
+  }
+}


### PR DESCRIPTION
The `lifen-fhir` dependency was missing in the package.json, resulting in the issue #6 

This PR fix the problem. 